### PR TITLE
Add another tag to distinguish transfers from same block. Pass timestamp as Date to be correctly handled to nanoseconds by the library

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ const influx = new Influx.InfluxDB({
 });
 
 const writePoints = (from, to, value, closureTime, blockNumber, blockTimestamp, transactionLogIndex) => {
-  var date = new Date(blockTimestamp*1000);
+  let date = new Date(blockTimestamp*1000);
 
   influx.writePoints([{
     measurement: 'transfers',
@@ -51,9 +51,9 @@ const writePoints = (from, to, value, closureTime, blockNumber, blockTimestamp, 
 }
 
 const PARITY_NODE = process.env.PARITY_URL || "http://localhost:8545";
-var web3 = new Web3(new Web3.providers.HttpProvider(PARITY_NODE));
+let web3 = new Web3(new Web3.providers.HttpProvider(PARITY_NODE));
 
-var batchTransferAbi = [{
+let batchTransferAbi = [{
   "anonymous": false,
   "inputs": [{
       "indexed": true,
@@ -80,7 +80,7 @@ var batchTransferAbi = [{
   "type": "event"
 }];
 
-var golemContract = new web3.eth.Contract(batchTransferAbi, GOLEM_CONTRACT_ADDRESS);
+let golemContract = new web3.eth.Contract(batchTransferAbi, GOLEM_CONTRACT_ADDRESS);
 
 const healthcheckInflux = () => {
   return influx.query("show measurements")
@@ -99,7 +99,7 @@ const getPastEvents = (startBlockNumber) => {
     })
     .then((events) => {
       events.forEach(function (batchTranfer) {
-        var {
+        let {
           transactionLogIndex,
           blockNumber,
           returnValues: {


### PR DESCRIPTION
1. The timestamp should be passed as nanoseconds, not seconds. Pass it as Date so the library can handle it internally.

2. Add a tag to uniquely distinguish between transfers in the same block (in the BachTransfer) as they are in the same block and have the same timestamp. The timestamp was the only unique tag before